### PR TITLE
When Lease is selected on Front Desk Menu, only display isLeasable vehicles

### DIFF
--- a/src/com/tti/FrontDeskMenu.java
+++ b/src/com/tti/FrontDeskMenu.java
@@ -15,6 +15,7 @@ public class FrontDeskMenu {
 		String address = null;
 		Vehicle vehicle;
 		int salesPreferenceNumber;
+		boolean leaseFilter;
 
 		if (firstTimeLoading) {
 			System.out.print("Are you ready to enter new client information? (Y/N): ");
@@ -54,10 +55,16 @@ public class FrontDeskMenu {
 			
 			// Collect sale preference input
 			salesPreferenceNumber = scanner.nextInt();
+			if (salesPreferenceNumber == 2) {
+				leaseFilter = true;
+			}
+			else {
+				leaseFilter = false;
+			}
 
 			// Print out current vehicle inventory
 			System.out.println("\nCurrent vehicle inventory: ");
-			VehicleInventory.printInventory();
+			VehicleInventory.printInventory(leaseFilter);
 			
 			System.out.print("\nPlease enter the client's chosen vehicle stock number: ");
 			vehicle = VehicleInventory.getVehicleInventory().get(scanner.nextInt());

--- a/src/com/tti/VehicleInventory.java
+++ b/src/com/tti/VehicleInventory.java
@@ -26,8 +26,9 @@ public class VehicleInventory {
 	    		inventory.put(VehicleArray[i].getStockNumber(), VehicleArray[i]);
 	    	}
 	    }
-	    public static void printInventory() {
+	    public static void printInventory(boolean leaseFilter) {
 	    	inventory.forEach((key, value) -> {
+	    		if (!leaseFilter) {
 	    		System.out.println(
 	    				inventory.get(key).getStockNumber() + " " + 
 	    				inventory.get(key).getModelYear() + " " + 
@@ -35,6 +36,16 @@ public class VehicleInventory {
 	    				inventory.get(key).getMake() + " " + 
 	    				inventory.get(key).getModel() + " "
 	    				);
+	    		}
+	    		else if (inventory.get(key).isLeasable()) {
+		    		System.out.println(
+		    				inventory.get(key).getStockNumber() + " " + 
+		    				inventory.get(key).getModelYear() + " " + 
+		    				inventory.get(key).getColor() + " " + 
+		    				inventory.get(key).getMake() + " " + 
+		    				inventory.get(key).getModel() + " "
+		    				);
+	    		}
 	    	});
 	    }
 	    

--- a/test/com/tti/VehicleInventoryTest.java
+++ b/test/com/tti/VehicleInventoryTest.java
@@ -22,7 +22,7 @@ public class VehicleInventoryTest {
         final ByteArrayOutputStream outContent = new ByteArrayOutputStream();
         System.setOut(new PrintStream(outContent));
 
-    	VehicleInventory.printInventory();
+    	VehicleInventory.printInventory(true);
     	assertTrue(outContent.toString().contains("2019 Purple Toyota Prius"));
     }
 	


### PR DESCRIPTION
In `FrontDeskMenu` class:

Add boolean `leaseFilter` and set it to true if sales preference is `Lease`, then pass it as an argument to `VehicleInventory.printInventory` method.


In `VehicleInventory` class:

Added `leaseFilter` parameter in `printInventory` and only display all vehicles when `leaseFilter` is set to `false`.


In `VehicleInventoryTest` class:

Added `true` argument to `VehicleInventory.printInventory` method.
