### PR TITLE
Hide Vehicles While They're in a Sale Request Ticket

### DIFF
--- a/src/com/tti/FrontDeskMenu.java
+++ b/src/com/tti/FrontDeskMenu.java
@@ -61,6 +61,7 @@ public class FrontDeskMenu {
 			
 			System.out.print("\nPlease enter the client's chosen vehicle stock number: ");
 			vehicle = VehicleInventory.getVehicleInventory().get(scanner.nextInt());
+			vehicle.setActive(true);
 			
 			switch(salesPreferenceNumber) {
 			// Create a sale request ticket and store in the Finance queue

--- a/src/com/tti/SalesMenu.java
+++ b/src/com/tti/SalesMenu.java
@@ -65,7 +65,9 @@ public class SalesMenu {
 					if (input.toLowerCase().contains("y")) {
 						VehicleInventory.removeVehicle(vehicle.getStockNumber());;
 					}
-
+					else {
+						vehicle.setActive(false);
+					}
 
 				}
 

--- a/src/com/tti/Vehicle.java
+++ b/src/com/tti/Vehicle.java
@@ -14,6 +14,7 @@ public class Vehicle implements IVehicle {
     private String color; //Declares vehicle color as String
     private String vin; //Declares vehicle vin as String
     private String vehicleType; // Placeholder until functionality added (Using enum)
+    private boolean isActive; //True when added to a Sale Request
     private boolean isLeasable; // Declares isLeasable variable as boolean
     private int leaseTerm; //Declares leaseTerm as integer in months
     private int maxMilesPerYear; //Declares Max Miles Per Year as integer
@@ -41,6 +42,7 @@ public class Vehicle implements IVehicle {
         this.setColor(color);
         this.setVin(vin);
         this.setVehicleType(vehicleType);
+        this.isActive = false;
         this.setLeasable(isLeasable);
         this.setLeaseTerm(leaseTerm);
         this.setMaxMilesPerYear(maxMilesPerYear);
@@ -162,6 +164,20 @@ public class Vehicle implements IVehicle {
     }
 
     /**
+	 * @return the isActive
+	 */
+	public boolean isActive() {
+		return isActive;
+	}
+
+	/**
+	 * @param isActive the isActive to set
+	 */
+	public void setActive(boolean isActive) {
+		this.isActive = isActive;
+	}
+
+	/**
      * @return the isLeasable
      */
     public boolean isLeasable() {

--- a/src/com/tti/VehicleInventory.java
+++ b/src/com/tti/VehicleInventory.java
@@ -28,23 +28,25 @@ public class VehicleInventory {
 	    }
 	    public static void printInventory(boolean leaseFilter) {
 	    	inventory.forEach((key, value) -> {
-	    		if (!leaseFilter) {
-	    		System.out.println(
-	    				inventory.get(key).getStockNumber() + " " + 
-	    				inventory.get(key).getModelYear() + " " + 
-	    				inventory.get(key).getColor() + " " + 
-	    				inventory.get(key).getMake() + " " + 
-	    				inventory.get(key).getModel() + " "
-	    				);
-	    		}
-	    		else if (inventory.get(key).isLeasable()) {
-		    		System.out.println(
+	    		if (!inventory.get(key).isActive()) {
+	    			if (!leaseFilter) {
+	    				System.out.println(
+	    					inventory.get(key).getStockNumber() + " " + 
+	    					inventory.get(key).getModelYear() + " " + 
+	    					inventory.get(key).getColor() + " " + 
+	    					inventory.get(key).getMake() + " " + 
+	    					inventory.get(key).getModel() + " "
+	    					);
+	    			}
+	    			else if (inventory.get(key).isLeasable()) {
+	    				System.out.println(
 		    				inventory.get(key).getStockNumber() + " " + 
 		    				inventory.get(key).getModelYear() + " " + 
 		    				inventory.get(key).getColor() + " " + 
 		    				inventory.get(key).getMake() + " " + 
 		    				inventory.get(key).getModel() + " "
 		    				);
+	    			}
 	    		}
 	    	});
 	    }


### PR DESCRIPTION
In `Vehicle` class:

Added `isActive` property, set to `false` by default, with getter and setter.


In `FrontDeskMenu` class:

Set `isActive` to `true` when `vehicle` is selected from the inventory list.


In `VehicleInventory` class:

Change `printInventory` to only list `vehicle` with `isActive` set to `false`.


In `SalesMenu` class:

Set `isActive` back to `false` if Sale Request ticket removed without a sale.
