### PR TITLE
Display Lease Details in Lease Queue

### DIFF
--- a/src/com/tti/SalesMenu.java
+++ b/src/com/tti/SalesMenu.java
@@ -64,8 +64,8 @@ public class SalesMenu {
 					System.out.println("Lease Term: " + vehicle.getLeaseTerm() + " Months");
 					System.out.println("Maximum Mileage Per Year: " + NumberFormat.getInstance().format(vehicle.getMaxMilesPerYear()));
 					System.out.println("Mileage Penalty (Per 5000 Miles): $" + String.format( "%.2f", vehicle.getMileagePenalty()));
-
-
+					
+					leaseFilter = false;
 				}
 				System.out.println("Remove client from the queue? (Y/N)");
 				input = scanner.next();

--- a/src/com/tti/SalesMenu.java
+++ b/src/com/tti/SalesMenu.java
@@ -1,5 +1,6 @@
 package com.tti;
 
+import java.text.NumberFormat;
 import java.util.Queue;
 import java.util.Scanner;
 
@@ -14,6 +15,7 @@ public class SalesMenu {
 		Queue<Object> myQueue = null;
 		String myName = null;
 		String input = null;
+		boolean leaseFilter = false;
 
 		switch (selection) {
 		case 2: myQueue = Queues.Finance;
@@ -21,6 +23,7 @@ public class SalesMenu {
 			break;
 		case 3: myQueue = Queues.Lease;
 		myName = "Lease";
+		leaseFilter = true;
 			break;
 		case 4: myQueue = Queues.FullSale;
 		myName = "Full Sale";
@@ -48,13 +51,21 @@ public class SalesMenu {
 				System.out.println("Make: " + vehicle.getMake());
 				System.out.println("Model: " + vehicle.getModel());
 				System.out.println("Color: " + vehicle.getColor());
-				System.out.println("Retail Price: " + vehicle.getRetailPrice());
-				System.out.println("Wholesale Price: " + vehicle.getWholesaleCost());
+				System.out.println("Retail Price: $" + NumberFormat.getInstance().format(vehicle.getRetailPrice()));
+				System.out.println("Wholesale Price: $" + NumberFormat.getInstance().format(vehicle.getWholesaleCost()));
 				if (vehicle.getVehicleType() == "LightTruck") {
 					System.out.println("Towing Capacity: " + " lbs.");
 					System.out.println("Gross Combined Weight: " + " lbs.");
 					System.out.println("Truck Weight: " + " lbs.");
 					System.out.println("4WD: " + " lbs.");
+				}
+				if (leaseFilter) {
+					System.out.println("\r\nVehicle Lease Details:\r\n");
+					System.out.println("Lease Term: " + vehicle.getLeaseTerm() + " Months");
+					System.out.println("Maximum Mileage Per Year: " + NumberFormat.getInstance().format(vehicle.getMaxMilesPerYear()));
+					System.out.println("Mileage Penalty (Per 5000 Miles): $" + String.format( "%.2f", vehicle.getMileagePenalty()));
+
+
 				}
 				System.out.println("Remove client from the queue? (Y/N)");
 				input = scanner.next();

--- a/src/com/tti/VehicleInventory.java
+++ b/src/com/tti/VehicleInventory.java
@@ -12,13 +12,13 @@ public class VehicleInventory {
 	    public static void populateHashMap() {
 	    	Vehicle vehicle1 = new Vehicle(20000, 22000, 2019, "Toyota", "Corolla", "Black", "36876G7dD8d9HJ", "CAR", false, 0, 0);
 	    	Vehicle vehicle2 = new Vehicle(30000, 34000, 2020, "Toyota", "Camry", "Silver", "638F7dDD8d79D7", "CAR", false, 0, 0);
-	    	Vehicle vehicle3 = new Vehicle(36000, 42000, 2019, "Toyota", "Prius", "Blue", "5H876G7dD8d9HJ", "CAR", true, 3, 12000);
+	    	Vehicle vehicle3 = new Vehicle(36000, 42000, 2019, "Toyota", "Prius", "Blue", "5H876G7dD8d9HJ", "CAR", true, 36, 12000);
 	    	Vehicle vehicle4 = new Vehicle(32000, 38000, 2020, "Toyota", "Avalon", "Red", "111HH4JDD8d9HJ", "CAR", false, 0, 0);
-	    	Vehicle vehicle5 = new Vehicle(36000, 42000, 2019, "Toyota", "Prius", "Purple", "5k54kk5G7dD8d9HJ", "CAR", true, 3, 12000);
-	    	Vehicle vehicle6 = new Vehicle(36000, 42000, 2019, "Toyota", "Prius", "Grey", "F9SH9H349HSDU", "CAR", true, 3, 12000);
+	    	Vehicle vehicle5 = new Vehicle(36000, 42000, 2019, "Toyota", "Prius", "Purple", "5k54kk5G7dD8d9HJ", "CAR", true, 36, 12000);
+	    	Vehicle vehicle6 = new Vehicle(36000, 42000, 2019, "Toyota", "Prius", "Grey", "F9SH9H349HSDU", "CAR", true, 36, 12000);
 	    	Vehicle vehicle7 = new Vehicle(20000, 22000, 2018, "Toyota", "Corolla", "Orange", "44JF34JF9H444", "CAR", false, 0, 0);
-	    	Vehicle vehicle8 = new Vehicle(30000, 34000, 2020, "Toyota", "Camry", "Silver", "F98NE97RN9SNF", "CAR", true, 3, 12000);
-	    	Vehicle vehicle9 = new Vehicle(36000, 42000, 2019, "Toyota", "Prius", "Metallic Blue", "498FN9834N93477F", "CAR", true, 3, 12000);
+	    	Vehicle vehicle8 = new Vehicle(30000, 34000, 2020, "Toyota", "Camry", "Silver", "F98NE97RN9SNF", "CAR", true, 36, 12000);
+	    	Vehicle vehicle9 = new Vehicle(36000, 42000, 2019, "Toyota", "Prius", "Metallic Blue", "498FN9834N93477F", "CAR", true, 36, 12000);
 	    	
 	    	Vehicle[] VehicleArray = {vehicle1, vehicle2, vehicle3, vehicle4, vehicle5, vehicle6, vehicle7, vehicle8, vehicle9};
 	    	


### PR DESCRIPTION
In `SalesMenu` class:

1. Added `leaseFilter` property, set to `false` by default, and set to `true` when `Lease` menu is loaded.
2. Display lease details for `vehicle` if `leaseFilter` is set to `true`.
3. Added formatting to insert commas into numbers and round to two decimal places.


In `VehicleInventory` class:

Changed `leaseTerm` arguments in `populateHashMap` to reflect months instead of years.
